### PR TITLE
Unix release script

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
@@ -112,6 +112,11 @@
 							<blocklink onclick='Events.pushevent("show help_textentry", event)'><translate>Colour codes and symbols</translate></blocklink>
 						</indent>
 
+						<h2><translate>Welcome</translate></h2>
+						<indent>
+							<blocklink onclick='Events.pushevent("show welcome", event)'><translate>Change log</translate></blocklink>
+						</indent>
+
 						<br />
 
 						<blocklink class="rightfloat" onclick='Events.pushevent("exec quit", event)'><translate>Quit game</translate></blocklink>

--- a/pkg/unvanquished_src.dpkdir/ui/welcome.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/welcome.rml
@@ -19,6 +19,12 @@
 				<translate>Welcome to Unvanquished</translate>
 				<br />
 				<br />
+				This mod is based on commit aa0df65ca110b69e073acb167d57886de3dbc398, dated from 2023-06-19.<br/>
+				Here is a list of (some) noticeable changes:<br/><br/>
+				<ul>
+					<include src="changelog"/>
+				</ul>
+				<br/><br/>
 				<translate>Close this menu and click anywhere to join a team and begin playing!</translate>
 			</panel>
 		</tabset>

--- a/release.sh
+++ b/release.sh
@@ -26,7 +26,7 @@ do
 	cp pkg/unvanquished_src.dpkdir/"$file" "$DEST/$file"
 done
 
-git log --oneline $START..HEAD | grep '^[0-9a-f]* [A-Z]*:' > $DEST/changelog
+git log --oneline $START..HEAD | sed -n '/^[0-9a-f]* [A-Z]*:/ s!^[^ ]*\(.*\)!•<li>\1<br/></li>! p' >> $DEST/changelog
 git format-patch -o $DEST/patches $START..HEAD
 find $DEST -name '.*' -exec rm -r {} \+
 rm release.dpk

--- a/release.sh
+++ b/release.sh
@@ -11,7 +11,7 @@ DEST=relpkg
 
 test -d relbuild || die "relbuild dir not found"
 cd relbuild
-make
+make --quiet || die "unable to compile"
 cd -
 rm -r $DEST
 mkdir $DEST

--- a/release.sh
+++ b/release.sh
@@ -27,7 +27,9 @@ do
 done
 
 git log --oneline $START..HEAD | sed -n '/^[0-9a-f]* [A-Z]*:/ s!^[^ ]*\(.*\)!•<li>\1<br/></li>! p' >> $DEST/changelog
-git format-patch -o $DEST/patches $START..HEAD
+git format-patch --quiet -o $DEST/patches $START..HEAD
+tar -c -f $DEST/patches.tar $DEST/patches
+rm -r $DEST/patches
 find $DEST -name '.*' -exec rm -r {} \+
 rm release.dpk
 cd $DEST

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+die()
+{
+	echo $@
+	exit
+}
+
+START=ancestor
+DEST=relpkg
+
+test -d relbuild || die "relbuild dir not found"
+cd relbuild
+make
+cd -
+rm -r $DEST
+mkdir $DEST
+for file in relbuild/*-stripped.nexe
+do
+	cp $file $DEST/$(basename $file -stripped.nexe).nexe
+done
+
+for file in $(git log --stat=150 --oneline --since "Sun Jan 29 18:30:00 2023 +0000" -- pkg | grep '|' | cut -d '|' -f1 | sort | uniq | cut -f1,2 --complement -d'/')
+do
+	mkdir -p "$DEST/$(dirname $file)"
+	cp pkg/unvanquished_src.dpkdir/"$file" "$DEST/$file"
+done
+
+git log --oneline $START..HEAD | grep '^[0-9a-f]* [A-Z]*:' > $DEST/changelog
+git format-patch -o $DEST/patches $START..HEAD
+find $DEST -name '.*' -exec rm -r {} \+
+rm release.dpk
+cd $DEST
+7z -tzip -mx=9 a ../release.dpk .


### PR DESCRIPTION
This is a bourne shell script that allows to build a release based on git history, bakes a changelog, and put the patches in the archive since an "ancestor" commit.
The interest of the last point is, this allows to easily rebuild a specific version of a mod, as long as you have the archive.
That problem hit me more than once when I was working on betterai, with the constant rebase breaking history.