### PR TITLE
server-side improvements to the BP Vampire mode

### DIFF
--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -70,18 +70,14 @@ float G_RGSPredictEfficiencyDelta(vec3_t origin, team_t team) {
  * @brief Calculate the build point budgets for both teams.
  */
 
-void G_UpdateBPVampire( int client )
+void G_UpdateBPVampire( int client ) // -1 to update everyone
 {
-	if ( client > -1 )
+	if ( !g_BPTransfer.Get() )
 	{
-		trap_SendServerCommand( client, va( "bpvampire %d %d", g_BPInitialBudgetHumans.Get(), g_BPInitialBudgetAliens.Get() ) );
 		return;
 	}
 
-	for ( int i = 0; i < level.maxclients; i++ )
-	{
-		trap_SendServerCommand( i, va( "bpvampire %d %d", g_BPInitialBudgetHumans.Get(), g_BPInitialBudgetAliens.Get() ) );
-	}
+	trap_SendServerCommand( client, va( "bpvampire %d %d", g_BPInitialBudgetHumans.Get(), g_BPInitialBudgetAliens.Get() ) );
 }
 
 void G_UpdateBuildPointBudgets() {

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -198,7 +198,7 @@ static const gentity_t *G_FindKillAssist( const gentity_t *self, const gentity_t
 	return assistant;
 }
 
-static Cvar::Cvar<bool> g_BPTransfer("g_BPTransfer", "BP transfer experiment", Cvar::NONE, false);
+Cvar::Cvar<bool> g_BPTransfer("g_BPTransfer", "BP transfer experiment", Cvar::NONE, false);
 static Cvar::Cvar<bool> g_BPTransferNotifyTeam("g_BPTransferNotifyTeam", "BP transfer experiment team notifications", Cvar::NONE, true);
 static Cvar::Cvar<float> g_BPTransferFactor("g_BPTransferFactor", "BP transfer factor", Cvar::NONE, 1.f);
 
@@ -310,10 +310,8 @@ void G_AnnounceStolenBP()
 		{
 			continue;
 		}
-		for ( int i = 0; i < level.maxclients; i++ )
-		{
-			trap_SendServerCommand( i, va( "bpvampire %d %d", g_BPInitialBudgetHumans.Get(), g_BPInitialBudgetAliens.Get() ) );
-		}
+		
+		G_UpdateBPVampire( -1 ); // update the BP bars for everyone
 
 		AnnounceDestructions( team );
 

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -92,6 +92,7 @@ extern  Cvar::Callback<Cvar::Cvar<int>> g_BPInitialBudgetAliens;
 extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner;
 extern  Cvar::Cvar<int> g_buildPointRecoveryInitialRate;
 extern  Cvar::Cvar<int> g_buildPointRecoveryRateHalfLife;
+extern  Cvar::Cvar<bool> g_BPTransfer;
 
 extern Cvar::Range<Cvar::Cvar<int>> g_debugMomentum;
 extern Cvar::Cvar<float> g_momentumHalfLife;

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -893,6 +893,20 @@ static void Svcmd_G_AdvanceMapRotation_f()
 	G_AdvanceMapRotation( 0 );
 }
 
+static void Svcmd_G_UpdateBPVampire_f()
+{
+	if ( !g_BPTransfer.Get() )
+	{
+		Log::Notice( "BP Vampire mode is not enabled." );
+		return;
+	}
+	
+	Log::Notice( "^3NOTE: DEVELOPMENT COMMAND:\n"
+	             "^3      this command should only be used when a manual\n"
+	             "^3      change is made to G_BPInitialBudget{Aliens|Humans}" );
+	G_UpdateBPVampire( -1 );
+}
+
 static const struct svcmd
 {
 	const char *cmd;
@@ -929,6 +943,7 @@ static const struct svcmd
 	{ "say",                true,  Svcmd_MessageWrapper         },
 	{ "say_team",           true,  Svcmd_TeamMessage_f          },
 	{ "stopMapRotation",    false, G_StopMapRotation            },
+	{ "updateBPVampire",    false, Svcmd_G_UpdateBPVampire_f    },
 };
 
 /*


### PR DESCRIPTION
this commit introduces the command: /updateBPVampire, to be used when manual changes are made to the BPInitialBudget, it can be removed later once a better system is in place for storing the stolen BP.

this commit also replaces the use of a loop with the G_UpdateBPVampire( -1 ) function.